### PR TITLE
M2 - Definición equipo. #117

### DIFF
--- a/pkg/modelos/equipo.go
+++ b/pkg/modelos/equipo.go
@@ -1,12 +1,16 @@
 package modelos
 
+import "time"
+
 type Equipo struct {
 	listaNombreAmigoDentoDelGrupo []string
+	fechaCreacion                 time.Time
 }
 
 func NewEquipo() Equipo {
 	return Equipo{
 		listaNombreAmigoDentoDelGrupo: []string{},
+		fechaCreacion:                 time.Now(),
 	}
 }
 
@@ -14,8 +18,13 @@ func (e Equipo) ObtenerEquipo() []string {
 	return e.listaNombreAmigoDentoDelGrupo
 }
 
+func (e Equipo) ObtenerFechaCreacion() string {
+	return e.fechaCreacion.Format("02-01-2006")
+}
+
 func (e Equipo) RellenarEquipo(nombreAmigoDentroDelGrupo []string) Equipo {
 	return Equipo{
 		listaNombreAmigoDentoDelGrupo: nombreAmigoDentroDelGrupo,
+		fechaCreacion:                 e.fechaCreacion,
 	}
 }

--- a/pkg/modelos/equipo.go
+++ b/pkg/modelos/equipo.go
@@ -1,0 +1,21 @@
+package modelos
+
+type Equipo struct {
+	listaNombreAmigoDentoDelGrupo []string
+}
+
+func NewEquipo() Equipo {
+	return Equipo{
+		listaNombreAmigoDentoDelGrupo: []string{},
+	}
+}
+
+func (e Equipo) ObtenerEquipo() []string {
+	return e.listaNombreAmigoDentoDelGrupo
+}
+
+func (e Equipo) RellenarEquipo(nombreAmigoDentroDelGrupo []string) Equipo {
+	return Equipo{
+		listaNombreAmigoDentoDelGrupo: nombreAmigoDentroDelGrupo,
+	}
+}

--- a/pkg/modelos/equipo_test.go
+++ b/pkg/modelos/equipo_test.go
@@ -1,0 +1,22 @@
+package modelos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEquipo(t *testing.T) {
+
+	Equipo := NewEquipo()
+	assert.Equal(t, []string{}, Equipo.ObtenerEquipo())
+
+}
+
+func TestRellenarEquipo(t *testing.T) {
+
+	Equipo := NewEquipo()
+	ListaAmigosEquipo1 := []string{"Amigo1", "Amigo2", "Amigo3", "Amigo4", "Amigo5"}
+	Equipo = Equipo.RellenarEquipo(ListaAmigosEquipo1)
+	assert.Equal(t, ListaAmigosEquipo1, Equipo.ObtenerEquipo())
+}

--- a/pkg/modelos/equipo_test.go
+++ b/pkg/modelos/equipo_test.go
@@ -2,6 +2,7 @@ package modelos
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -9,7 +10,9 @@ import (
 func TestNewEquipo(t *testing.T) {
 
 	Equipo := NewEquipo()
+	fechaEsperada := time.Now().Format("02-01-2006")
 	assert.Equal(t, []string{}, Equipo.ObtenerEquipo())
+	assert.Equal(t, fechaEsperada, Equipo.ObtenerFechaCreacion())
 
 }
 


### PR DESCRIPTION
Se ha definido el objeto valor equipo como una lista de nombres que hacen referencia a los amigos de ese grupo que pertenecen a ese equipo.
Se ha declarado el objeto equipo como inmutable, siendo los equipos definitivos una vez que estos se rellenen. closes #117