### PR TITLE
Repartir jugadores en equipos igualados. #123

### DIFF
--- a/pkg/modelos/grupo.go
+++ b/pkg/modelos/grupo.go
@@ -9,6 +9,7 @@ import (
 const (
 	DisponibilidadPorDefecto             bool = true
 	CantidadAmigosMinimaParaCrearEquipos      = 10
+	DiferenciaDeNivelMaximaEntreEquipos       = 1
 )
 
 var (
@@ -219,7 +220,7 @@ func (g *GrupoAmigos) EstanIgualados(Equipo1 Equipo, Equipo2 Equipo) bool {
 		NivelEquipo1 := float64(NivelTotalEquipo1) / float64(len(Equipo1.ObtenerEquipo()))
 		NivelEquipo2 := float64(NivelTotalEquipo2) / float64(len(Equipo2.ObtenerEquipo()))
 
-		if (NivelEquipo1+1.5 > NivelEquipo2) && (NivelEquipo2+1.5 > NivelEquipo1) {
+		if (NivelEquipo1+DiferenciaDeNivelMaximaEntreEquipos > NivelEquipo2) && (NivelEquipo2+DiferenciaDeNivelMaximaEntreEquipos > NivelEquipo1) {
 			Igualados = true
 		}
 

--- a/pkg/modelos/grupo.go
+++ b/pkg/modelos/grupo.go
@@ -2,6 +2,7 @@ package modelos
 
 import (
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -16,7 +17,16 @@ var (
 	ErrorAmigoInexistente                            = fmt.Errorf("No existe el amigo indicado dentro del grupo de amigos")
 	ErrorListaAmigosVacia                            = fmt.Errorf("No se puede crear un grupo de amigos con una lista de amigos vacía")
 	ErrorJugadoresDisponiblesNoAptosParaCrearEquipos = fmt.Errorf("No se pueden crear 2 equipos igualados si la cantidad de amigos disponibles no es un número par mayor o igual a 10")
+	ErrorImposibilidadCrearEquiposIgualados          = fmt.Errorf("Ha sido imposible crear 2 equipos igualados con la lista de jugadores disponibles")
 )
+
+func FormatearErrorAmigoDuplicado(identificador string) error {
+	return fmt.Errorf(ErrorAmigoDuplicado.Error() + ": " + identificador)
+}
+
+func FormatearErrorAmigoInexistente(identificador string) error {
+	return fmt.Errorf(ErrorAmigoInexistente.Error() + ": " + identificador)
+}
 
 var EstadoAmigoPorDefecto EstadoAmigo = EstadoAmigo{
 	Nivel:      NivelPorOmision,
@@ -64,7 +74,7 @@ func (g *GrupoAmigos) CrearAmigoYAniadirAlGrupo(nickAmigo string, fechaNacimient
 	_, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if existe {
-		return ErrorAmigoDuplicado
+		return FormatearErrorAmigoDuplicado(amigo.ObtenerId())
 	}
 
 	g.ListaAmigos = append(g.ListaAmigos, amigo)
@@ -77,7 +87,7 @@ func (g *GrupoAmigos) CambiarDisponibilidadAmigo(amigo Amigo, disponibilidad boo
 	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if !existe {
-		return ErrorAmigoInexistente
+		return FormatearErrorAmigoInexistente(amigo.ObtenerId())
 	}
 
 	estado.Disponible = disponibilidad
@@ -90,7 +100,7 @@ func (g *GrupoAmigos) AumentarNivelAmigo(amigo Amigo) error {
 	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if !existe {
-		return ErrorAmigoInexistente
+		return FormatearErrorAmigoInexistente(amigo.ObtenerId())
 	}
 
 	estado.Nivel = estado.Nivel.AumentarNivel()
@@ -103,7 +113,7 @@ func (g *GrupoAmigos) DisminuirNivelAmigo(amigo Amigo) error {
 	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if !existe {
-		return ErrorAmigoInexistente
+		return FormatearErrorAmigoInexistente(amigo.ObtenerId())
 	}
 
 	estado.Nivel = estado.Nivel.DisminuirNivel()
@@ -112,13 +122,13 @@ func (g *GrupoAmigos) DisminuirNivelAmigo(amigo Amigo) error {
 	return nil
 }
 
-func (g *GrupoAmigos) GrupoAmigosListoParaCrearEquipos(estadosAmigos map[string]EstadoAmigo) (bool, error) {
+func (g *GrupoAmigos) GrupoAmigosListoParaCrearEquipos(estadosAmigos map[string]EstadoAmigo) (bool, []string, error) {
 	amigosDisponibles := g.ObtenerListaAmigosDisponibles(estadosAmigos)
 	if (len(amigosDisponibles) < CantidadAmigosMinimaParaCrearEquipos) || (len(amigosDisponibles)%2 != 0) {
-		return false, ErrorJugadoresDisponiblesNoAptosParaCrearEquipos
+		return false, nil, ErrorJugadoresDisponiblesNoAptosParaCrearEquipos
 	}
 
-	return true, nil
+	return true, amigosDisponibles, nil
 
 }
 
@@ -131,5 +141,89 @@ func (g *GrupoAmigos) ObtenerListaAmigosDisponibles(estadosAmigos map[string]Est
 		}
 	}
 
+	sort.SliceStable(amigosDisponibles, func(i, j int) bool {
+		return estadosAmigos[amigosDisponibles[i]].Nivel > estadosAmigos[amigosDisponibles[j]].Nivel
+	})
+
 	return amigosDisponibles
+}
+
+func (g *GrupoAmigos) CrearDosEquiposIgualados(estadosAmigos map[string]EstadoAmigo) (Equipo, Equipo, error) {
+	listo, listaAmigosDisponiblesOrdenados, errorListaAmigos := g.GrupoAmigosListoParaCrearEquipos(estadosAmigos)
+
+	if !listo {
+		return Equipo{}, Equipo{}, errorListaAmigos
+	}
+
+	equipo1, equipo2 := g.RepartirJugadoresDisponiblesEnDosEquiposSegunNivel(listaAmigosDisponiblesOrdenados)
+
+	igualados := g.EstanIgualados(equipo1, equipo2)
+
+	if !igualados {
+		return Equipo{}, Equipo{}, ErrorImposibilidadCrearEquiposIgualados
+	}
+
+	return equipo1, equipo2, nil
+
+}
+
+func (g *GrupoAmigos) RepartirJugadoresDisponiblesEnDosEquiposSegunNivel(ListaAmigosDisponiblesOrdenados []string) (Equipo, Equipo) {
+	var EquipoA []string
+	var EquipoB []string
+	var NivelTotalEquipoA uint
+	var NivelTotalEquipoB uint
+
+	for _, Amigo := range ListaAmigosDisponiblesOrdenados {
+
+		if len(EquipoA) == 0 && len(EquipoB) == 0 {
+			EquipoA = append(EquipoA, Amigo)
+			NivelTotalEquipoA += uint(g.NivelYDisponibilidadAmigos[Amigo].Nivel)
+		} else if len(EquipoB) == 0 {
+			EquipoB = append(EquipoB, Amigo)
+			NivelTotalEquipoB += uint(g.NivelYDisponibilidadAmigos[Amigo].Nivel)
+		} else if (NivelTotalEquipoA < NivelTotalEquipoB) && (len(EquipoA) < (len(ListaAmigosDisponiblesOrdenados) / 2)) {
+			EquipoA = append(EquipoA, Amigo)
+			NivelTotalEquipoA += uint(g.NivelYDisponibilidadAmigos[Amigo].Nivel)
+		} else if len(EquipoB) < (len(ListaAmigosDisponiblesOrdenados) / 2) {
+			EquipoB = append(EquipoB, Amigo)
+			NivelTotalEquipoB += uint(g.NivelYDisponibilidadAmigos[Amigo].Nivel)
+		} else {
+			EquipoA = append(EquipoA, Amigo)
+			NivelTotalEquipoA += uint(g.NivelYDisponibilidadAmigos[Amigo].Nivel)
+		}
+	}
+
+	Equipo := NewEquipo()
+	PrimerEquipo := Equipo.RellenarEquipo(EquipoA)
+	SegundoEquipo := Equipo.RellenarEquipo(EquipoB)
+
+	return PrimerEquipo, SegundoEquipo
+
+}
+
+func (g *GrupoAmigos) EstanIgualados(Equipo1 Equipo, Equipo2 Equipo) bool {
+	Igualados := false
+	var NivelTotalEquipo1 uint = 0
+	var NivelTotalEquipo2 uint = 0
+
+	if len(Equipo1.listaNombreAmigoDentoDelGrupo) == len(Equipo2.listaNombreAmigoDentoDelGrupo) && len(Equipo1.listaNombreAmigoDentoDelGrupo) >= 5 {
+
+		for _, jugador := range Equipo1.ObtenerEquipo() {
+			NivelTotalEquipo1 += uint(g.NivelYDisponibilidadAmigos[jugador].Nivel)
+		}
+
+		for _, jugador := range Equipo2.ObtenerEquipo() {
+			NivelTotalEquipo2 += uint(g.NivelYDisponibilidadAmigos[jugador].Nivel)
+		}
+
+		NivelEquipo1 := float64(NivelTotalEquipo1) / float64(len(Equipo1.ObtenerEquipo()))
+		NivelEquipo2 := float64(NivelTotalEquipo2) / float64(len(Equipo2.ObtenerEquipo()))
+
+		if (NivelEquipo1+1.5 > NivelEquipo2) && (NivelEquipo2+1.5 > NivelEquipo1) {
+			Igualados = true
+		}
+
+	}
+
+	return Igualados
 }

--- a/pkg/modelos/grupo.go
+++ b/pkg/modelos/grupo.go
@@ -21,12 +21,8 @@ var (
 	ErrorImposibilidadCrearEquiposIgualados          = fmt.Errorf("Ha sido imposible crear 2 equipos igualados con la lista de jugadores disponibles")
 )
 
-func FormatearErrorAmigoDuplicado(identificador string) error {
-	return fmt.Errorf(ErrorAmigoDuplicado.Error() + ": " + identificador)
-}
-
-func FormatearErrorAmigoInexistente(identificador string) error {
-	return fmt.Errorf(ErrorAmigoInexistente.Error() + ": " + identificador)
+func FormatearError(e error, identificador string) error {
+	return fmt.Errorf(e.Error() + ": " + identificador)
 }
 
 var EstadoAmigoPorDefecto EstadoAmigo = EstadoAmigo{
@@ -75,7 +71,7 @@ func (g *GrupoAmigos) CrearAmigoYAniadirAlGrupo(nickAmigo string, fechaNacimient
 	_, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if existe {
-		return FormatearErrorAmigoDuplicado(amigo.ObtenerId())
+		return FormatearError(ErrorAmigoDuplicado, amigo.ObtenerId())
 	}
 
 	g.ListaAmigos = append(g.ListaAmigos, amigo)
@@ -88,7 +84,7 @@ func (g *GrupoAmigos) CambiarDisponibilidadAmigo(amigo Amigo, disponibilidad boo
 	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if !existe {
-		return FormatearErrorAmigoInexistente(amigo.ObtenerId())
+		return FormatearError(ErrorAmigoInexistente, amigo.ObtenerId())
 	}
 
 	estado.Disponible = disponibilidad
@@ -101,7 +97,7 @@ func (g *GrupoAmigos) AumentarNivelAmigo(amigo Amigo) error {
 	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if !existe {
-		return FormatearErrorAmigoInexistente(amigo.ObtenerId())
+		return FormatearError(ErrorAmigoInexistente, amigo.ObtenerId())
 	}
 
 	estado.Nivel = estado.Nivel.AumentarNivel()
@@ -114,7 +110,7 @@ func (g *GrupoAmigos) DisminuirNivelAmigo(amigo Amigo) error {
 	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
 
 	if !existe {
-		return FormatearErrorAmigoInexistente(amigo.ObtenerId())
+		return FormatearError(ErrorAmigoInexistente, amigo.ObtenerId())
 	}
 
 	estado.Nivel = estado.Nivel.DisminuirNivel()

--- a/pkg/modelos/grupo_test.go
+++ b/pkg/modelos/grupo_test.go
@@ -7,6 +7,44 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	amigo1, _              = NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
+	amigo2, _              = NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
+	amigo3, _              = NewAmigo("Jose", time.Date(1999, time.December, 1, 0, 0, 0, 0, time.Now().Location()))
+	amigo4, _              = NewAmigo("Javi", time.Date(1999, time.September, 7, 0, 0, 0, 0, time.Now().Location()))
+	amigo5, _              = NewAmigo("Guille", time.Date(1999, time.February, 17, 0, 0, 0, 0, time.Now().Location()))
+	amigo6, _              = NewAmigo("Manu", time.Date(1999, time.June, 27, 0, 0, 0, 0, time.Now().Location()))
+	amigo7, _              = NewAmigo("Alex", time.Date(1999, time.July, 13, 0, 0, 0, 0, time.Now().Location()))
+	amigo8, _              = NewAmigo("Jorge", time.Date(1999, time.July, 3, 0, 0, 0, 0, time.Now().Location()))
+	amigo9, _              = NewAmigo("Sergio", time.Date(1999, time.May, 4, 0, 0, 0, 0, time.Now().Location()))
+	amigo10, _             = NewAmigo("Fran", time.Date(1999, time.March, 8, 0, 0, 0, 0, time.Now().Location()))
+	ListaAmigosCompleta    = []Amigo{amigo1, amigo2, amigo3, amigo4, amigo5, amigo6, amigo7, amigo8, amigo9, amigo10}
+	EstadosAmigosImposible = map[string]EstadoAmigo{
+		"Javi17August":     {NivelMaximo, DisponibilidadPorDefecto},
+		"Migue22January":   {NivelMinimo, DisponibilidadPorDefecto},
+		"Jose1December":    {NivelMinimo, DisponibilidadPorDefecto},
+		"Javi7September":   {NivelMinimo, DisponibilidadPorDefecto},
+		"Guille17February": {NivelMinimo, DisponibilidadPorDefecto},
+		"Manu27June":       {NivelMinimo, DisponibilidadPorDefecto},
+		"Alex13July":       {NivelMinimo, DisponibilidadPorDefecto},
+		"Jorge3July":       {NivelMinimo, DisponibilidadPorDefecto},
+		"Sergio4May":       {NivelMinimo, DisponibilidadPorDefecto},
+		"Fran8March":       {NivelMinimo, DisponibilidadPorDefecto},
+	}
+	EstadosAmigosPosible = map[string]EstadoAmigo{
+		"Javi17August":     {Nivel(2), DisponibilidadPorDefecto},
+		"Migue22January":   {Nivel(6), DisponibilidadPorDefecto},
+		"Jose1December":    {Nivel(1), DisponibilidadPorDefecto},
+		"Javi7September":   {Nivel(9), DisponibilidadPorDefecto},
+		"Guille17February": {Nivel(0), DisponibilidadPorDefecto},
+		"Manu27June":       {Nivel(5), DisponibilidadPorDefecto},
+		"Alex13July":       {Nivel(4), DisponibilidadPorDefecto},
+		"Jorge3July":       {Nivel(3), DisponibilidadPorDefecto},
+		"Sergio4May":       {Nivel(8), DisponibilidadPorDefecto},
+		"Fran8March":       {Nivel(7), DisponibilidadPorDefecto},
+	}
+)
+
 func TestNewGrupoAmigos(t *testing.T) {
 
 	amigo, _ := NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
@@ -165,20 +203,9 @@ func TestCrearEquiposIgualados(t *testing.T) {
 	assert.EqualError(t, errorCrearEquipos, ErrorJugadoresDisponiblesNoAptosParaCrearEquipos.Error())
 
 	//Caso incorrecto por imposibilidad de crear 2 equipos igualados
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Jose", time.Date(1999, time.December, 1, 0, 0, 0, 0, time.Now().Location()))
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Javi", time.Date(1999, time.September, 7, 0, 0, 0, 0, time.Now().Location()))
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Guille", time.Date(1999, time.February, 17, 0, 0, 0, 0, time.Now().Location()))
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Manu", time.Date(1999, time.June, 27, 0, 0, 0, 0, time.Now().Location()))
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Alex", time.Date(1999, time.July, 13, 0, 0, 0, 0, time.Now().Location()))
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Jorge", time.Date(1999, time.July, 3, 0, 0, 0, 0, time.Now().Location()))
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Sergio", time.Date(1999, time.May, 4, 0, 0, 0, 0, time.Now().Location()))
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Fran", time.Date(1999, time.March, 8, 0, 0, 0, 0, time.Now().Location()))
+	grupo.ListaAmigos = ListaAmigosCompleta
 
-	for nombre := range grupo.NivelYDisponibilidadAmigos {
-		grupo.NivelYDisponibilidadAmigos[nombre] = EstadoAmigo{Nivel: 1, Disponible: true}
-	}
-
-	grupo.NivelYDisponibilidadAmigos["Javi17August"] = EstadoAmigo{Nivel: NivelMaximo, Disponible: true}
+	grupo.NivelYDisponibilidadAmigos = EstadosAmigosImposible
 
 	equipo1, equipo2, errorCrearEquipos = grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
 
@@ -187,16 +214,7 @@ func TestCrearEquiposIgualados(t *testing.T) {
 	assert.EqualError(t, errorCrearEquipos, ErrorImposibilidadCrearEquiposIgualados.Error())
 
 	//Caso correcto
-	grupo.NivelYDisponibilidadAmigos["Guille17February"] = EstadoAmigo{Nivel: Nivel(0), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Jose1December"] = EstadoAmigo{Nivel: Nivel(1), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Javi17August"] = EstadoAmigo{Nivel: Nivel(2), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Jorge3July"] = EstadoAmigo{Nivel: Nivel(3), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Alex13July"] = EstadoAmigo{Nivel: Nivel(4), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Manu27June"] = EstadoAmigo{Nivel: Nivel(5), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Migue22January"] = EstadoAmigo{Nivel: Nivel(6), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Fran8March"] = EstadoAmigo{Nivel: Nivel(7), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Sergio4May"] = EstadoAmigo{Nivel: Nivel(8), Disponible: true}
-	grupo.NivelYDisponibilidadAmigos["Javi7September"] = EstadoAmigo{Nivel: Nivel(9), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos = EstadosAmigosPosible
 
 	equipo1, equipo2, errorCrearEquipos = grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
 

--- a/pkg/modelos/grupo_test.go
+++ b/pkg/modelos/grupo_test.go
@@ -101,20 +101,16 @@ func TestModificarDisponibilidadAmigo(t *testing.T) {
 	amigo, _ := NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
 	amigo2, _ := NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
 	listaAmigos := []Amigo{amigo, amigo2}
+	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
 
 	//Caso incorrecto intentando cambiar disponibilidad de un amigo que no está en el grupo
-	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
-	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
 
-	errorDisponibilidad := grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
-	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
-
-	assert.EqualError(t, errorDisponibilidad, errorEsperado)
+	assertModificarAmigoInexistente(t, grupo, "Disponibilidad")
 
 	//Caso correcto
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
-	amigoNuevo = grupo.ListaAmigos[2]
-	errorDisponibilidad = grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
+	amigoNuevo := grupo.ListaAmigos[2]
+	errorDisponibilidad := grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
 	estado := grupo.NivelYDisponibilidadAmigos[amigoNuevo.ObtenerId()]
 
 	assert.Nil(t, errorDisponibilidad)
@@ -128,9 +124,9 @@ func TestAumentarNivelAmigo(t *testing.T) {
 	listaAmigos := []Amigo{amigo, amigo2}
 	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
 
-	//Caso incorrecto intentando cambiar disponibilidad de un amigo que no está en el grupo
+	//Caso incorrecto intentando aumentar nivel de un amigo que no está en el grupo
 
-	assertCambiarNivelAAmigoInexistente(t, grupo)
+	assertModificarAmigoInexistente(t, grupo, "Aumentar")
 
 	//Caso correcto sin alcanzar el límite
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
@@ -156,8 +152,9 @@ func TestDisminuirNivelAmigo(t *testing.T) {
 	amigo2, _ := NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
 	listaAmigos := []Amigo{amigo, amigo2}
 	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
-	//Caso incorrecto intentando cambiar disponibilidad de un amigo que no está en el grupo
-	assertCambiarNivelAAmigoInexistente(t, grupo)
+
+	//Caso incorrecto intentando disminuir de un amigo que no está en el grupo
+	assertModificarAmigoInexistente(t, grupo, "Disminuir")
 
 	//Caso correcto sin alcanzar el límite
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
@@ -178,13 +175,21 @@ func TestDisminuirNivelAmigo(t *testing.T) {
 
 }
 
-func assertCambiarNivelAAmigoInexistente(t *testing.T, grupo *GrupoAmigos) {
+func assertModificarAmigoInexistente(t *testing.T, grupo *GrupoAmigos, tipo string) {
 	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
-
-	errorNivel := grupo.AumentarNivelAmigo(amigoNuevo)
 	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
 
-	assert.EqualError(t, errorNivel, errorEsperado)
+	var errorInexistente error
+
+	if tipo == "Aumentar" {
+		errorInexistente = grupo.AumentarNivelAmigo(amigoNuevo)
+	} else if tipo == "Disminuir" {
+		errorInexistente = grupo.DisminuirNivelAmigo(amigoNuevo)
+	} else if tipo == "Disponibilidad" {
+		errorInexistente = grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
+	}
+
+	assert.EqualError(t, errorInexistente, errorEsperado)
 }
 
 func TestCrearEquiposIgualados(t *testing.T) {

--- a/pkg/modelos/grupo_test.go
+++ b/pkg/modelos/grupo_test.go
@@ -126,20 +126,16 @@ func TestAumentarNivelAmigo(t *testing.T) {
 	amigo, _ := NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
 	amigo2, _ := NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
 	listaAmigos := []Amigo{amigo, amigo2}
+	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
 
 	//Caso incorrecto intentando cambiar disponibilidad de un amigo que no está en el grupo
-	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
-	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
 
-	errorNivel := grupo.AumentarNivelAmigo(amigoNuevo)
-	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
-
-	assert.EqualError(t, errorNivel, errorEsperado)
+	assertCambiarNivelAAmigoInexistente(t, grupo)
 
 	//Caso correcto sin alcanzar el límite
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
 	amigoAniadido := grupo.ListaAmigos[2]
-	errorNivel = grupo.AumentarNivelAmigo(amigoAniadido)
+	errorNivel := grupo.AumentarNivelAmigo(amigoAniadido)
 
 	assert.Nil(t, errorNivel)
 	assert.Greater(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelPorOmision)
@@ -159,20 +155,14 @@ func TestDisminuirNivelAmigo(t *testing.T) {
 	amigo, _ := NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
 	amigo2, _ := NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
 	listaAmigos := []Amigo{amigo, amigo2}
-
-	//Caso incorrecto intentando cambiar disponibilidad de un amigo que no está en el grupo
 	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
-	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
-
-	errorNivel := grupo.AumentarNivelAmigo(amigoNuevo)
-	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
-
-	assert.EqualError(t, errorNivel, errorEsperado)
+	//Caso incorrecto intentando cambiar disponibilidad de un amigo que no está en el grupo
+	assertCambiarNivelAAmigoInexistente(t, grupo)
 
 	//Caso correcto sin alcanzar el límite
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
 	amigoAniadido := grupo.ListaAmigos[2]
-	errorNivel = grupo.DisminuirNivelAmigo(amigoAniadido)
+	errorNivel := grupo.DisminuirNivelAmigo(amigoAniadido)
 
 	assert.Nil(t, errorNivel)
 	assert.Less(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelPorOmision)
@@ -186,6 +176,15 @@ func TestDisminuirNivelAmigo(t *testing.T) {
 	assert.Nil(t, errorNivel)
 	assert.Equal(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelMinimo)
 
+}
+
+func assertCambiarNivelAAmigoInexistente(t *testing.T, grupo *GrupoAmigos) {
+	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
+
+	errorNivel := grupo.AumentarNivelAmigo(amigoNuevo)
+	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
+
+	assert.EqualError(t, errorNivel, errorEsperado)
 }
 
 func TestCrearEquiposIgualados(t *testing.T) {

--- a/pkg/modelos/grupo_test.go
+++ b/pkg/modelos/grupo_test.go
@@ -186,4 +186,25 @@ func TestCrearEquiposIgualados(t *testing.T) {
 	assert.Equal(t, Equipo{}, equipo2)
 	assert.EqualError(t, errorCrearEquipos, ErrorImposibilidadCrearEquiposIgualados.Error())
 
+	//Caso correcto
+	grupo.NivelYDisponibilidadAmigos["Guille17February"] = EstadoAmigo{Nivel: Nivel(0), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Jose1December"] = EstadoAmigo{Nivel: Nivel(1), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Javi17August"] = EstadoAmigo{Nivel: Nivel(2), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Jorge3July"] = EstadoAmigo{Nivel: Nivel(3), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Alex13July"] = EstadoAmigo{Nivel: Nivel(4), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Manu27June"] = EstadoAmigo{Nivel: Nivel(5), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Migue22January"] = EstadoAmigo{Nivel: Nivel(6), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Fran8March"] = EstadoAmigo{Nivel: Nivel(7), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Sergio4May"] = EstadoAmigo{Nivel: Nivel(8), Disponible: true}
+	grupo.NivelYDisponibilidadAmigos["Javi7September"] = EstadoAmigo{Nivel: Nivel(9), Disponible: true}
+
+	equipo1, equipo2, errorCrearEquipos = grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+
+	listaEquipo1Esperada := []string{"Javi7September", "Migue22January", "Alex13July", "Jorge3July", "Guille17February"}
+	listaEquipo2Esperada := []string{"Sergio4May", "Fran8March", "Manu27June", "Javi17August", "Jose1December"}
+
+	assert.Equal(t, listaEquipo1Esperada, equipo1.listaNombreAmigoDentoDelGrupo)
+	assert.Equal(t, listaEquipo2Esperada, equipo2.listaNombreAmigoDentoDelGrupo)
+	assert.Nil(t, errorCrearEquipos)
+
 }

--- a/pkg/modelos/grupo_test.go
+++ b/pkg/modelos/grupo_test.go
@@ -69,8 +69,9 @@ func TestModificarDisponibilidadAmigo(t *testing.T) {
 	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
 
 	errorDisponibilidad := grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
+	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
 
-	assert.EqualError(t, errorDisponibilidad, ErrorAmigoInexistente.Error())
+	assert.EqualError(t, errorDisponibilidad, errorEsperado)
 
 	//Caso correcto
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
@@ -93,8 +94,9 @@ func TestAumentarNivelAmigo(t *testing.T) {
 	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
 
 	errorNivel := grupo.AumentarNivelAmigo(amigoNuevo)
+	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
 
-	assert.EqualError(t, errorNivel, ErrorAmigoInexistente.Error())
+	assert.EqualError(t, errorNivel, errorEsperado)
 
 	//Caso correcto sin alcanzar el límite
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
@@ -125,8 +127,9 @@ func TestDisminuirNivelAmigo(t *testing.T) {
 	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
 
 	errorNivel := grupo.AumentarNivelAmigo(amigoNuevo)
+	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
 
-	assert.EqualError(t, errorNivel, ErrorAmigoInexistente.Error())
+	assert.EqualError(t, errorNivel, errorEsperado)
 
 	//Caso correcto sin alcanzar el límite
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
@@ -144,5 +147,43 @@ func TestDisminuirNivelAmigo(t *testing.T) {
 	errorNivel = grupo.DisminuirNivelAmigo(amigoAniadido)
 	assert.Nil(t, errorNivel)
 	assert.Equal(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelMinimo)
+
+}
+
+func TestCrearEquiposIgualados(t *testing.T) {
+
+	// Caso incorrecto no hay jugadores suficientes
+	amigo, _ := NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
+	amigo2, _ := NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
+	listaAmigos := []Amigo{amigo, amigo2}
+	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
+
+	equipo1, equipo2, errorCrearEquipos := grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+
+	assert.Equal(t, Equipo{}, equipo1)
+	assert.Equal(t, Equipo{}, equipo2)
+	assert.EqualError(t, errorCrearEquipos, ErrorJugadoresDisponiblesNoAptosParaCrearEquipos.Error())
+
+	//Caso incorrecto por imposibilidad de crear 2 equipos igualados
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Jose", time.Date(1999, time.December, 1, 0, 0, 0, 0, time.Now().Location()))
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Javi", time.Date(1999, time.September, 7, 0, 0, 0, 0, time.Now().Location()))
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Guille", time.Date(1999, time.February, 17, 0, 0, 0, 0, time.Now().Location()))
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Manu", time.Date(1999, time.June, 27, 0, 0, 0, 0, time.Now().Location()))
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Alex", time.Date(1999, time.July, 13, 0, 0, 0, 0, time.Now().Location()))
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Jorge", time.Date(1999, time.July, 3, 0, 0, 0, 0, time.Now().Location()))
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Sergio", time.Date(1999, time.May, 4, 0, 0, 0, 0, time.Now().Location()))
+	_ = grupo.CrearAmigoYAniadirAlGrupo("Fran", time.Date(1999, time.March, 8, 0, 0, 0, 0, time.Now().Location()))
+
+	for nombre := range grupo.NivelYDisponibilidadAmigos {
+		grupo.NivelYDisponibilidadAmigos[nombre] = EstadoAmigo{Nivel: 1, Disponible: true}
+	}
+
+	grupo.NivelYDisponibilidadAmigos["Javi17August"] = EstadoAmigo{Nivel: NivelMaximo, Disponible: true}
+
+	equipo1, equipo2, errorCrearEquipos = grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+
+	assert.Equal(t, Equipo{}, equipo1)
+	assert.Equal(t, Equipo{}, equipo2)
+	assert.EqualError(t, errorCrearEquipos, ErrorImposibilidadCrearEquiposIgualados.Error())
 
 }


### PR DESCRIPTION
En primer lugar, se ha modificado el método de comprobar si el grupo está preparado para crear 2 equipos añadiendo que en caso correcto devuelva la lista de jugadores disponibles ordenados por nivel descendente. A continuación, se ha creado el algoritmo de distribución de jugadores. Tambien se ha establecido como criterio de aceptación de 2 equipos igualados sea que el nivel medio de los jugadores que forman ambos equipos sea inferior a 1.5. Por último, se ha formateado las salidas de error de jugadores duplicados e inexistentes. closes #123