### PR TITLE
M3 - Gestión niveles post-partido. #126

### DIFF
--- a/pkg/modelos/grupo.go
+++ b/pkg/modelos/grupo.go
@@ -17,7 +17,7 @@ var (
 	ErrorAmigoDuplicado                              = fmt.Errorf("Ya existe un amigo con ese identificador")
 	ErrorAmigoInexistente                            = fmt.Errorf("No existe el amigo indicado dentro del grupo de amigos")
 	ErrorListaAmigosVacia                            = fmt.Errorf("No se puede crear un grupo de amigos con una lista de amigos vacía")
-	ErrorJugadoresDisponiblesNoAptosParaCrearEquipos = fmt.Errorf("No se pueden crear 2 equipos igualados si la cantidad de amigos disponibles no es un número par mayor o igual a 10")
+	ErrorJugadoresDisponiblesNoAptosParaCrearEquipos = fmt.Errorf("No se pueden crear 2 equipos igualados si la cantidad de amigos disponibles no es un número par mayor o igual a 10, Cantidad actual")
 	ErrorImposibilidadCrearEquiposIgualados          = fmt.Errorf("Ha sido imposible crear 2 equipos igualados con la lista de jugadores disponibles")
 	ErrorEquiposPartidoDistinto                      = fmt.Errorf("Los equipos introducidos no son del mismo partido ya que tienen fechas diferentes")
 )
@@ -127,7 +127,7 @@ func (g *GrupoAmigos) DisminuirNivelEquipo(equipo Equipo) error {
 func (g *GrupoAmigos) GrupoAmigosListoParaCrearEquipos(estadosAmigos map[string]EstadoAmigo) (bool, []string, error) {
 	amigosDisponibles := g.ObtenerListaAmigosDisponibles(estadosAmigos)
 	if (len(amigosDisponibles) < CantidadAmigosMinimaParaCrearEquipos) || (len(amigosDisponibles)%2 != 0) {
-		return false, nil, ErrorJugadoresDisponiblesNoAptosParaCrearEquipos
+		return false, nil, FormatearError(ErrorJugadoresDisponiblesNoAptosParaCrearEquipos, fmt.Sprint(len(amigosDisponibles)))
 	}
 
 	return true, amigosDisponibles, nil
@@ -232,7 +232,8 @@ func (g *GrupoAmigos) EstanIgualados(Equipo1 Equipo, Equipo2 Equipo) bool {
 
 func (g *GrupoAmigos) ModificarNivelesTrasPartido(Equipo1 Equipo, ResultadoEquipo1 uint, Equipo2 Equipo, ResultadoEquipo2 uint) error {
 	if Equipo1.ObtenerFechaCreacion() != Equipo2.ObtenerFechaCreacion() {
-		return ErrorEquiposPartidoDistinto
+		mensaje := fmt.Sprint(Equipo1.ObtenerFechaCreacion()) + " != " + fmt.Sprint(Equipo2.ObtenerEquipo())
+		return FormatearError(ErrorEquiposPartidoDistinto, mensaje)
 	}
 
 	if ResultadoEquipo1 != ResultadoEquipo2 {

--- a/pkg/modelos/grupo.go
+++ b/pkg/modelos/grupo.go
@@ -19,6 +19,7 @@ var (
 	ErrorListaAmigosVacia                            = fmt.Errorf("No se puede crear un grupo de amigos con una lista de amigos vacía")
 	ErrorJugadoresDisponiblesNoAptosParaCrearEquipos = fmt.Errorf("No se pueden crear 2 equipos igualados si la cantidad de amigos disponibles no es un número par mayor o igual a 10")
 	ErrorImposibilidadCrearEquiposIgualados          = fmt.Errorf("Ha sido imposible crear 2 equipos igualados con la lista de jugadores disponibles")
+	ErrorEquiposPartidoDistinto                      = fmt.Errorf("Los equipos introducidos no son del mismo partido ya que tienen fechas diferentes")
 )
 
 func FormatearError(e error, identificador string) error {
@@ -93,28 +94,32 @@ func (g *GrupoAmigos) CambiarDisponibilidadAmigo(amigo Amigo, disponibilidad boo
 	return nil
 }
 
-func (g *GrupoAmigos) AumentarNivelAmigo(amigo Amigo) error {
-	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
+func (g *GrupoAmigos) AumentarNivelEquipo(equipo Equipo) error {
+	for _, amigo := range equipo.ObtenerEquipo() {
+		estado, existe := g.NivelYDisponibilidadAmigos[amigo]
 
-	if !existe {
-		return FormatearError(ErrorAmigoInexistente, amigo.ObtenerId())
+		if !existe {
+			return FormatearError(ErrorAmigoInexistente, amigo)
+		}
+
+		estado.Nivel = estado.Nivel.AumentarNivel()
+		g.NivelYDisponibilidadAmigos[amigo] = estado
 	}
-
-	estado.Nivel = estado.Nivel.AumentarNivel()
-	g.NivelYDisponibilidadAmigos[amigo.ObtenerId()] = estado
 
 	return nil
 }
 
-func (g *GrupoAmigos) DisminuirNivelAmigo(amigo Amigo) error {
-	estado, existe := g.NivelYDisponibilidadAmigos[amigo.ObtenerId()]
+func (g *GrupoAmigos) DisminuirNivelEquipo(equipo Equipo) error {
+	for _, amigo := range equipo.ObtenerEquipo() {
+		estado, existe := g.NivelYDisponibilidadAmigos[amigo]
 
-	if !existe {
-		return FormatearError(ErrorAmigoInexistente, amigo.ObtenerId())
+		if !existe {
+			return FormatearError(ErrorAmigoInexistente, amigo)
+		}
+
+		estado.Nivel = estado.Nivel.DisminuirNivel()
+		g.NivelYDisponibilidadAmigos[amigo] = estado
 	}
-
-	estado.Nivel = estado.Nivel.DisminuirNivel()
-	g.NivelYDisponibilidadAmigos[amigo.ObtenerId()] = estado
 
 	return nil
 }
@@ -223,4 +228,35 @@ func (g *GrupoAmigos) EstanIgualados(Equipo1 Equipo, Equipo2 Equipo) bool {
 	}
 
 	return Igualados
+}
+
+func (g *GrupoAmigos) ModificarNivelesTrasPartido(Equipo1 Equipo, ResultadoEquipo1 uint, Equipo2 Equipo, ResultadoEquipo2 uint) error {
+	if Equipo1.ObtenerFechaCreacion() != Equipo2.ObtenerFechaCreacion() {
+		return ErrorEquiposPartidoDistinto
+	}
+
+	if ResultadoEquipo1 != ResultadoEquipo2 {
+
+		if ResultadoEquipo1 > ResultadoEquipo2 {
+			errorEquipo := g.AumentarNivelEquipo(Equipo1)
+			if errorEquipo != nil {
+				return errorEquipo
+			}
+			errorEquipo = g.DisminuirNivelEquipo(Equipo2)
+			if errorEquipo != nil {
+				return errorEquipo
+			}
+		} else {
+			errorEquipo := g.AumentarNivelEquipo(Equipo2)
+			if errorEquipo != nil {
+				return errorEquipo
+			}
+			errorEquipo = g.DisminuirNivelEquipo(Equipo1)
+			if errorEquipo != nil {
+				return errorEquipo
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/modelos/grupo_test.go
+++ b/pkg/modelos/grupo_test.go
@@ -1,6 +1,7 @@
 package modelos
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -129,10 +130,11 @@ func TestCrearEquiposIgualados(t *testing.T) {
 	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
 
 	equipo1, equipo2, errorCrearEquipos := grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+	errorEsperado := ErrorJugadoresDisponiblesNoAptosParaCrearEquipos.Error() + ": " + fmt.Sprint(2)
 
 	assert.Equal(t, Equipo{}, equipo1)
 	assert.Equal(t, Equipo{}, equipo2)
-	assert.EqualError(t, errorCrearEquipos, ErrorJugadoresDisponiblesNoAptosParaCrearEquipos.Error())
+	assert.EqualError(t, errorCrearEquipos, errorEsperado)
 
 	//Caso incorrecto por imposibilidad de crear 2 equipos igualados
 	grupo.ListaAmigos = ListaAmigosCompleta
@@ -163,17 +165,10 @@ func TestModificarNivelesTrasPartido(t *testing.T) {
 	grupo, _ := NewGrupoAmigos("Prueba", ListaAmigosCompleta)
 	grupo.NivelYDisponibilidadAmigos = EstadosAmigosPosible
 
-	//Caso incorrecto con equipos de distintas fechas
-	equipo1, equipo2, _ := grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
-	equipo1.fechaCreacion = time.Date(2023, time.June, 19, 0, 0, 0, 0, time.Now().Location())
-
-	errorModificarNiveles := grupo.ModificarNivelesTrasPartido(equipo1, 3, equipo2, 4)
-	assert.EqualError(t, errorModificarNiveles, ErrorEquiposPartidoDistinto.Error())
-
 	//Caso correcto con resultado igualado donde no se modifican los niveles
 
-	equipo1, equipo2, _ = grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
-	errorModificarNiveles = grupo.ModificarNivelesTrasPartido(equipo1, 3, equipo2, 3)
+	equipo1, equipo2, _ := grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+	errorModificarNiveles := grupo.ModificarNivelesTrasPartido(equipo1, 3, equipo2, 3)
 
 	assert.Nil(t, errorModificarNiveles)
 	assert.Equal(t, EstadosAmigosPosible, grupo.NivelYDisponibilidadAmigos)

--- a/pkg/modelos/grupo_test.go
+++ b/pkg/modelos/grupo_test.go
@@ -104,92 +104,20 @@ func TestModificarDisponibilidadAmigo(t *testing.T) {
 	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
 
 	//Caso incorrecto intentando cambiar disponibilidad de un amigo que no está en el grupo
-
-	assertModificarAmigoInexistente(t, grupo, "Disponibilidad")
+	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
+	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
+	errorInexistente := grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
+	assert.EqualError(t, errorInexistente, errorEsperado)
 
 	//Caso correcto
 	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
-	amigoNuevo := grupo.ListaAmigos[2]
+	amigoNuevo = grupo.ListaAmigos[2]
 	errorDisponibilidad := grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
 	estado := grupo.NivelYDisponibilidadAmigos[amigoNuevo.ObtenerId()]
 
 	assert.Nil(t, errorDisponibilidad)
 	assert.False(t, estado.Disponible)
 
-}
-
-func TestAumentarNivelAmigo(t *testing.T) {
-	amigo, _ := NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
-	amigo2, _ := NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
-	listaAmigos := []Amigo{amigo, amigo2}
-	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
-
-	//Caso incorrecto intentando aumentar nivel de un amigo que no está en el grupo
-
-	assertModificarAmigoInexistente(t, grupo, "Aumentar")
-
-	//Caso correcto sin alcanzar el límite
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
-	amigoAniadido := grupo.ListaAmigos[2]
-	errorNivel := grupo.AumentarNivelAmigo(amigoAniadido)
-
-	assert.Nil(t, errorNivel)
-	assert.Greater(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelPorOmision)
-
-	//Caso correcto alcanzando el límite
-
-	estado := grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()]
-	estado.Nivel = NivelMaximo
-	grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()] = estado
-	errorNivel = grupo.AumentarNivelAmigo(amigoAniadido)
-	assert.Nil(t, errorNivel)
-	assert.Equal(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelMaximo)
-}
-
-func TestDisminuirNivelAmigo(t *testing.T) {
-
-	amigo, _ := NewAmigo("Javi", time.Date(1999, time.August, 17, 0, 0, 0, 0, time.Now().Location()))
-	amigo2, _ := NewAmigo("Migue", time.Date(2001, time.January, 22, 0, 0, 0, 0, time.Now().Location()))
-	listaAmigos := []Amigo{amigo, amigo2}
-	grupo, _ := NewGrupoAmigos("Prueba", listaAmigos)
-
-	//Caso incorrecto intentando disminuir de un amigo que no está en el grupo
-	assertModificarAmigoInexistente(t, grupo, "Disminuir")
-
-	//Caso correcto sin alcanzar el límite
-	_ = grupo.CrearAmigoYAniadirAlGrupo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
-	amigoAniadido := grupo.ListaAmigos[2]
-	errorNivel := grupo.DisminuirNivelAmigo(amigoAniadido)
-
-	assert.Nil(t, errorNivel)
-	assert.Less(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelPorOmision)
-
-	//Caso correcto alcanzando el límite
-
-	estado := grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()]
-	estado.Nivel = NivelMinimo
-	grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()] = estado
-	errorNivel = grupo.DisminuirNivelAmigo(amigoAniadido)
-	assert.Nil(t, errorNivel)
-	assert.Equal(t, grupo.NivelYDisponibilidadAmigos[amigoAniadido.ObtenerId()].Nivel, NivelMinimo)
-
-}
-
-func assertModificarAmigoInexistente(t *testing.T, grupo *GrupoAmigos, tipo string) {
-	amigoNuevo, _ := NewAmigo("Migue", time.Date(1999, time.April, 27, 0, 0, 0, 0, time.Now().Location()))
-	errorEsperado := ErrorAmigoInexistente.Error() + ": " + amigoNuevo.ObtenerId()
-
-	var errorInexistente error
-
-	if tipo == "Aumentar" {
-		errorInexistente = grupo.AumentarNivelAmigo(amigoNuevo)
-	} else if tipo == "Disminuir" {
-		errorInexistente = grupo.DisminuirNivelAmigo(amigoNuevo)
-	} else if tipo == "Disponibilidad" {
-		errorInexistente = grupo.CambiarDisponibilidadAmigo(amigoNuevo, false)
-	}
-
-	assert.EqualError(t, errorInexistente, errorEsperado)
 }
 
 func TestCrearEquiposIgualados(t *testing.T) {
@@ -228,5 +156,39 @@ func TestCrearEquiposIgualados(t *testing.T) {
 	assert.Equal(t, listaEquipo1Esperada, equipo1.listaNombreAmigoDentoDelGrupo)
 	assert.Equal(t, listaEquipo2Esperada, equipo2.listaNombreAmigoDentoDelGrupo)
 	assert.Nil(t, errorCrearEquipos)
+
+}
+
+func TestModificarNivelesTrasPartido(t *testing.T) {
+	grupo, _ := NewGrupoAmigos("Prueba", ListaAmigosCompleta)
+	grupo.NivelYDisponibilidadAmigos = EstadosAmigosPosible
+
+	//Caso incorrecto con equipos de distintas fechas
+	equipo1, equipo2, _ := grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+	equipo1.fechaCreacion = time.Date(2023, time.June, 19, 0, 0, 0, 0, time.Now().Location())
+
+	errorModificarNiveles := grupo.ModificarNivelesTrasPartido(equipo1, 3, equipo2, 4)
+	assert.EqualError(t, errorModificarNiveles, ErrorEquiposPartidoDistinto.Error())
+
+	//Caso correcto con resultado igualado donde no se modifican los niveles
+
+	equipo1, equipo2, _ = grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+	errorModificarNiveles = grupo.ModificarNivelesTrasPartido(equipo1, 3, equipo2, 3)
+
+	assert.Nil(t, errorModificarNiveles)
+	assert.Equal(t, EstadosAmigosPosible, grupo.NivelYDisponibilidadAmigos)
+
+	//Caso correcto en el que se modifican los resultados ya que el resultado no es empate
+	grupo, _ = NewGrupoAmigos("Prueba", ListaAmigosCompleta)
+	equipo1, equipo2, _ = grupo.CrearDosEquiposIgualados(grupo.NivelYDisponibilidadAmigos)
+	errorModificarNiveles = grupo.ModificarNivelesTrasPartido(equipo1, 2, equipo2, 1)
+
+	assert.Nil(t, errorModificarNiveles)
+	for _, amigo := range equipo1.listaNombreAmigoDentoDelGrupo {
+		assert.Greater(t, grupo.NivelYDisponibilidadAmigos[amigo].Nivel, NivelPorOmision)
+	}
+	for _, amigo := range equipo2.listaNombreAmigoDentoDelGrupo {
+		assert.Less(t, grupo.NivelYDisponibilidadAmigos[amigo].Nivel, NivelPorOmision)
+	}
 
 }


### PR DESCRIPTION
En primer lugar se han cambiado las funciones de aumentar y decrementar nivel ya que estas solo se usan tras un partido y se aplican en conjunto a un equipo. Como no es algo ligado al comportamiento del usuario, se han eliminado los tests. Estas funciones se testean ahora dentro del test de modificar niveles post partido. Se ha establecido como criterio de modificación que se aumenta el nivel si se gana y se disminuye si se pierde, independientemente de lo abultado que sea el resultado. Si el partido queda en empate, todo queda igual. closes #126